### PR TITLE
parameterizing the destination of the newrelic.ini file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ php5_newrelic_daemon_loglevel: info
 php5_newrelic_high_security: no
 # Sets the name of the application that metrics will be reported into.
 php5_newrelic_appname: myapp
+# Sets the desination location of the newrelic.ini file
+php5_newrelic_config_dest: /etc/php5/mods-available/newrelic.ini

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,10 +2,8 @@
 
 - name: Configuring module
   template:
-    src: "{{ item }}.j2"
-    dest: "/{{ item }}"
+    src: "etc/php5/mods-available/newrelic.ini.j2"
+    dest: "{{ php5_newrelic_config_dest }}"
     owner: "root"
     group: "root"
     mode: "0644"
-  with_items:
-    - "etc/php5/mods-available/newrelic.ini"


### PR DESCRIPTION
Ran into some issues installing this plugin on my old php 5.3 system, so I needed to change the destination of where this newrelic.ini file ended up.  Largely the same as before, just parameterized.