### PR TITLE
Update tests and docs to refer to new Ansible Galaxy repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PWD=$(shell pwd)
-ROLE_NAME=franklinkim.php5-newrelic
+ROLE_NAME=weareinteractive.php5_newrelic
 ROLE_PATH=/etc/ansible/roles/$(ROLE_NAME)
 TEST_VERSION=ansible --version
-TEST_DEPS=ansible-galaxy install -c weareinteractive.apt franklinkim.php5 franklinkim.newrelic
+TEST_DEPS=ansible-galaxy install -c weareinteractive.apt weareinteractive.php5 weareinteractive.newrelic
 TEST_SYNTAX=ansible-playbook -vv -i 'localhost,' -c local $(ROLE_PATH)/tests/main.yml --syntax-check
 TEST_PLAYBOOK=ansible-playbook -vv -i 'localhost,' -c local $(ROLE_PATH)/tests/main.yml
 TEST_CMD=$(TEST_DEPS); $(TEST_VERSION); $(TEST_SYNTAX); $(TEST_PLAYBOOK)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Ansible franklinkim.php5-newrelic role
+# Ansible weareinteractive.php5_newrelic role
 
 [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-php5-newrelic.svg)](https://travis-ci.org/weareinteractive/ansible-php5-newrelic)
-[![Galaxy](http://img.shields.io/badge/galaxy-franklinkim.php5-newrelic-blue.svg)](https://galaxy.ansible.com/franklinkim/php5-newrelic)
+[![Galaxy](https://img.shields.io/badge/galaxy-weareinteractive.php5_newrelic-blue.svg)](https://galaxy.ansible.com/weareinteractive/php5-newrelic)
 [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-php5-newrelic.svg)](https://github.com/weareinteractive/ansible-php5-newrelic)
 [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-php5-newrelic.svg)](https://github.com/weareinteractive/ansible-php5-newrelic)
 
-> `franklinkim.php5-newrelic` is an [Ansible](http://www.ansible.com) role which:
+> `weareinteractive.php5_newrelic` is an [Ansible](http://www.ansible.com) role which:
 >
 > * installs newrelic php agent
 > * configures newrelic php agent
@@ -17,19 +17,19 @@
 Using `ansible-galaxy`:
 
 ```shell
-$ ansible-galaxy install franklinkim.php5-newrelic
+$ ansible-galaxy install weareinteractive.php5_newrelic
 ```
 
 Using `requirements.yml`:
 
 ```yaml
-- src: franklinkim.php5-newrelic
+- src: weareinteractive.php5_newrelic
 ```
 
 Using `git`:
 
 ```shell
-$ git clone https://github.com/weareinteractive/ansible-php5-newrelic.git franklinkim.php5-newrelic
+$ git clone https://github.com/weareinteractive/ansible-php5-newrelic.git weareinteractive.php5_newrelic
 ```
 
 ## Dependencies
@@ -73,17 +73,16 @@ This is an example playbook:
 
 ```yaml
 ---
-
 - hosts: all
   become: yes
   roles:
     - weareinteractive.apt
-    - franklinkim.newrelic
-    - franklinkim.php5
-    - franklinkim.php5-newrelic
+    - weareinteractive.newrelic
+    - weareinteractive.php5
+    - weareinteractive.php5-newrelic
   vars:
     apt_repositories:
-      - repo: 'ppa:ondrej/php5-oldstable'
+      - repo: "ppa:ondrej/php5-oldstable"
     newrelic_license_key: ab2fa361cd4d0d373833cad619d7bcc424d27c16
     php5_newrelic_appname: "My App"
     php5_newrelic_extra_config:

--- a/meta/readme.yml
+++ b/meta/readme.yml
@@ -1,11 +1,10 @@
 ---
-
-galaxy_name: franklinkim.php5-newrelic
+galaxy_name: weareinteractive.php5_newrelic
 github_user: weareinteractive
 github_name: ansible-php5-newrelic
 badges: |
   [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-php5-newrelic.svg)](https://travis-ci.org/weareinteractive/ansible-php5-newrelic)
-  [![Galaxy](http://img.shields.io/badge/galaxy-franklinkim.php5-newrelic-blue.svg)](https://galaxy.ansible.com/franklinkim/php5-newrelic)
+  [![Galaxy](https://img.shields.io/badge/galaxy-weareinteractive.php5_newrelic-blue.svg)](https://galaxy.ansible.com/weareinteractive/php5-newrelic)
   [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-php5-newrelic.svg)](https://github.com/weareinteractive/ansible-php5-newrelic)
   [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-php5-newrelic.svg)](https://github.com/weareinteractive/ansible-php5-newrelic)
 description: |

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,15 +1,14 @@
 ---
-
 - hosts: all
   become: yes
   roles:
     - weareinteractive.apt
-    - franklinkim.newrelic
-    - franklinkim.php5
-    - franklinkim.php5-newrelic
+    - weareinteractive.newrelic
+    - weareinteractive.php5
+    - weareinteractive.php5-newrelic
   vars:
     apt_repositories:
-      - repo: 'ppa:ondrej/php5-oldstable'
+      - repo: "ppa:ondrej/php5-oldstable"
     newrelic_license_key: ab2fa361cd4d0d373833cad619d7bcc424d27c16
     php5_newrelic_appname: "My App"
     php5_newrelic_extra_config:


### PR DESCRIPTION
This PR updates tests and documentation to refer to `weareinteractive.php5_newrelic` instead of `franklinkim.php5-newrelic`, which does not appear to exist on Ansible Galaxy anymore, but appears to be here now: https://galaxy.ansible.com/weareinteractive/php5-newrelic.